### PR TITLE
Fix issue #2 - Fade Starting channel not working correctly

### DIFF
--- a/sacn.js
+++ b/sacn.js
@@ -74,13 +74,13 @@ instance.prototype.fade = function(steps, delay, offset, targets) {
 	if ( steps ) {
 		self.server.send(self.packet);
 		for ( i=0; i < targets.length; i++ ) {
-			var delta = targets[i+offset] - self.data[i+offset];
+			var delta = targets[i] - self.data[i+offset];
 			self.data[i+offset] += Math.round(delta/steps) & 0xff;
 		}
 		setTimeout(function() {self.fade(--steps, delay, offset, targets);}, delay);
 	} else {
 		for ( i=0; i < targets.length; i++ ) {
-			self.data[i+offset] = targets[i+offset];
+			self.data[i+offset] = targets[i];
 		}
 		self.keepAlive();
 	}


### PR DESCRIPTION
Fixing the issue for "SACN: Fade To Values" where the "Starting Channel" field seemed to have no effect.
The starting channel offset was incorrectly applied to the `values` array resulting in the `undefined` values be applied to the data buffer which resulted in them being set to `00`.